### PR TITLE
User story 30

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -16,6 +16,7 @@ class OrdersController <ApplicationController
     order = current_user.orders.create(order_params)
     if order.save
       cart.items.each do |item,quantity|
+        item.modify_item_inventory(item, quantity, :decrease)
         order.item_orders.create({
           item: item,
           quantity: quantity,
@@ -40,6 +41,10 @@ class OrdersController <ApplicationController
     order = Order.find(params[:order_id])
     order.update(status: "cancelled")
     order.edit_item_orders
+    order.item_orders.each do |item, quantity|
+      item_to_restock = Item.find(item.item_id)
+      item_to_restock.modify_item_inventory(item_to_restock, item.quantity, :increase)
+    end
     flash[:success] = "Your order has been cancelled"
     redirect_to "/profile"
   end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -35,6 +35,14 @@ class OrdersController <ApplicationController
       render :new
     end
   end
+  
+  def update
+    order = Order.find(params[:order_id])
+    order.update(status: "cancelled")
+    order.edit_item_orders
+    flash[:success] = "Your order has been cancelled"
+    redirect_to "/profile"
+  end
 
 
   private

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -33,5 +33,15 @@ class Item <ApplicationRecord
     select('items.*, sum(quantity) as total').joins(:item_orders).group('items.id').order('total').limit(5)
 
   end
+  
+  def modify_item_inventory(item, quantity, action)
+    if action == :decrease
+      new_quantity = (item.inventory - quantity)
+      item.update(inventory: new_quantity)
+    elsif action == :increase
+      new_quantity = (item.inventory + quantity)
+      item.update(inventory: new_quantity)
+    end
+  end
 
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -15,14 +15,22 @@ class Order <ApplicationRecord
 
   def total_item_value(id)
      item_orders.joins(:item).where(items: {merchant_id: id}).sum(self.grandtotal)
-  end 
+  end
   
   def approved?
     all_items_status = item_orders.pluck(:status)
     if all_items_status.any?("pending")
-       "Pending"
+      "Pending"
+    elsif all_items_status.all?("unfulfilled")
+      "Cancelled"
     else
       "Approved"
+    end
+  end
+  
+  def edit_item_orders
+    self.item_orders.each do |item|
+      item.update(status: "unfillfilled")
     end
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -30,7 +30,7 @@ class Order <ApplicationRecord
   
   def edit_item_orders
     self.item_orders.each do |item|
-      item.update(status: "unfillfilled")
+      item.update(status: "unfulfilled")
     end
   end
 end

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -40,9 +40,9 @@
         <td><p><%= number_to_currency(item_order.subtotal)%></p></td>
       </section>
     </tr>
-    <p><%= button_to "Cancel Order", "/profile/orders/#{@order.id}", method: :patch %></p>
   <% end %>
 </table>
+<p><%= button_to "Cancel Order", "/profile/orders/#{@order.id}", method: :patch %></p>
 
 <section id="grandtotal">
   <p>Total: <%=number_to_currency(@order.grandtotal)%></p>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -40,6 +40,7 @@
         <td><p><%= number_to_currency(item_order.subtotal)%></p></td>
       </section>
     </tr>
+    <p><%= button_to "Cancel Order", "/profile/orders/#{@order.id}", method: :patch %></p>
   <% end %>
 </table>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,8 @@ Rails.application.routes.draw do
   get "/profile/password", to: 'users#edit_password'
   patch '/profile', to: 'users#update'
   put '/profile', to: 'users#update_password'
-  get "profile/orders", to: "orders#index"
+  get "/profile/orders", to: "orders#index"
+  patch "/profile/orders/:order_id", to: "orders#update"
 
   get "/login", to: "sessions#new"
   post "/login", to: "sessions#create"

--- a/spec/features/orders/creation_spec.rb
+++ b/spec/features/orders/creation_spec.rb
@@ -1,11 +1,3 @@
-# When I fill out all information on the new order page
-# And click on 'Create Order'
-# An order is created and saved in the database
-# And I am redirected to that order's show page with the following information:
-#
-# - Details of the order:
-
-# - the date when the order was created
 RSpec.describe("Order Creation") do
   describe "When I check out from my cart" do
     before(:each) do

--- a/spec/features/orders/destroy_spec.rb
+++ b/spec/features/orders/destroy_spec.rb
@@ -63,6 +63,8 @@ RSpec.describe("Order Cancellation") do
         
         expect(current_path).to eq("/profile")
         
+        order = Order.last
+        
         order.item_orders.each do |item|
           expect(item.status).to eq("unfulfilled")
         end

--- a/spec/features/orders/destroy_spec.rb
+++ b/spec/features/orders/destroy_spec.rb
@@ -1,0 +1,84 @@
+RSpec.describe("Order Cancellation") do
+
+    before(:each) do
+      @mike = Merchant.create(name: "Mike's Print Shop", address: '123 Paper Rd.', city: 'Denver', state: 'CO', zip: 80203)
+      @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+      @tire = @meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+      @paper = @mike.items.create(name: "Lined Paper", description: "Great for writing on!", price: 20, image: "https://cdn.vertex42.com/WordTemplates/images/printable-lined-paper-wide-ruled.png", inventory: 3)
+      @pencil = @mike.items.create(name: "Yellow Pencil", description: "You can write on paper with it!", price: 2, image: "https://images-na.ssl-images-amazon.com/images/I/31BlVr01izL._SX425_.jpg", inventory: 100)
+
+      @employee_user = User.create!(name: "Larry Richard", address: "1234 Bland St.", city: "Denver", state: "CO", zip: "80085", email: "employee_user@email.com", password: "123", role: 1, merchant_id: @meg.id)
+      @default_user = User.create!(name: "Harry Richard", address: "1234 Bland St.", city: "Denver", state: "CO", zip: "80085", email: "regular_user@email.com", password: "123", role: 0)
+
+      # allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit "/items"
+      click_on "Login"
+      fill_in :email, with: @default_user.email
+      fill_in :password, with: @default_user.password
+      click_on "Submit"
+
+      visit "/items/#{@paper.id}"
+      click_on "Add To Cart"
+      visit "/items/#{@paper.id}"
+      click_on "Add To Cart"
+      visit "/items/#{@tire.id}"
+      click_on "Add To Cart"
+      visit "/items/#{@pencil.id}"
+      click_on "Add To Cart"
+
+      visit "/cart"
+      click_on "Checkout"
+    end
+
+    it 'I can cancel an order' do
+      order = @default_user.orders.create({
+                                          name: "James",
+                                          address: "123 Main",
+                                          city: "Denver",
+                                          state: "CO",
+                                          zip: "88888"
+                                        })
+      
+      expect(@paper.inventory).to eq(3)
+      
+      order.item_orders.create({
+        item: @paper,
+        quantity: 2,
+        price: @paper.price,
+        status: "pending"
+        })
+        
+        visit "/orders/#{order.id}"
+        
+        order.item_orders.each do |item|
+          expect(item.status).to eq("pending")
+        end
+
+        expect(order.status).to eq("pending")
+        
+        expect(page).to have_button("Cancel Order")
+        
+        click_button "Cancel Order"
+        
+        expect(current_path).to eq("/profile")
+        
+        order.item_orders.each do |item|
+          expect(item.status).to eq("unfulfilled")
+        end
+        
+        expect(order.status).to eq("cancelled")
+        
+        expect(@paper.inventory).to eq(3)
+        
+        expect(page).to have_content("Your order has been cancelled")
+    end
+  end
+  
+  
+  
+  
+  
+  
+  
+  

--- a/spec/features/orders/destroy_spec.rb
+++ b/spec/features/orders/destroy_spec.rb
@@ -3,9 +3,8 @@ RSpec.describe("Order Cancellation") do
     before(:each) do
       @mike = Merchant.create(name: "Mike's Print Shop", address: '123 Paper Rd.', city: 'Denver', state: 'CO', zip: 80203)
       @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
-      @tire = @meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+
       @paper = @mike.items.create(name: "Lined Paper", description: "Great for writing on!", price: 20, image: "https://cdn.vertex42.com/WordTemplates/images/printable-lined-paper-wide-ruled.png", inventory: 3)
-      @pencil = @mike.items.create(name: "Yellow Pencil", description: "You can write on paper with it!", price: 2, image: "https://images-na.ssl-images-amazon.com/images/I/31BlVr01izL._SX425_.jpg", inventory: 100)
 
       @employee_user = User.create!(name: "Larry Richard", address: "1234 Bland St.", city: "Denver", state: "CO", zip: "80085", email: "employee_user@email.com", password: "123", role: 1, merchant_id: @meg.id)
       @default_user = User.create!(name: "Harry Richard", address: "1234 Bland St.", city: "Denver", state: "CO", zip: "80085", email: "regular_user@email.com", password: "123", role: 0)
@@ -22,58 +21,59 @@ RSpec.describe("Order Cancellation") do
       click_on "Add To Cart"
       visit "/items/#{@paper.id}"
       click_on "Add To Cart"
-      visit "/items/#{@tire.id}"
-      click_on "Add To Cart"
-      visit "/items/#{@pencil.id}"
-      click_on "Add To Cart"
 
       visit "/cart"
       click_on "Checkout"
     end
 
     it 'I can cancel an order' do
-      order = @default_user.orders.create({
-                                          name: "James",
-                                          address: "123 Main",
-                                          city: "Denver",
-                                          state: "CO",
-                                          zip: "88888"
-                                        })
       
       expect(@paper.inventory).to eq(3)
-      
-      order.item_orders.create({
-        item: @paper,
-        quantity: 2,
-        price: @paper.price,
-        status: "pending"
-        })
         
-        visit "/orders/#{order.id}"
-        
-        order.item_orders.each do |item|
-          expect(item.status).to eq("pending")
-        end
+      name = "Bert"
+      address = "123 Sesame St."
+      city = "NYC"
+      state = "New York"
+      zip = 10001
 
-        expect(order.status).to eq("pending")
-        
-        expect(page).to have_button("Cancel Order")
-        
-        click_button "Cancel Order"
-        
-        expect(current_path).to eq("/profile")
-        
-        order = Order.last
-        
-        order.item_orders.each do |item|
-          expect(item.status).to eq("unfulfilled")
-        end
-        
-        expect(order.status).to eq("cancelled")
-        
-        expect(@paper.inventory).to eq(3)
-        
-        expect(page).to have_content("Your order has been cancelled")
+      fill_in :name, with: name
+      fill_in :address, with: address
+      fill_in :city, with: city
+      fill_in :state, with: state
+      fill_in :zip, with: zip
+
+      click_button "Create Order"
+      order = Order.last
+      visit "/orders/#{order.id}"
+      
+      paper = Item.last
+      
+      expect(paper.inventory).to eq(1)
+      
+      order.item_orders.each do |item|
+        expect(item.status).to eq("pending")
+      end
+
+      expect(order.status).to eq("pending")
+      
+      expect(page).to have_button("Cancel Order")
+      
+      click_button "Cancel Order"
+      
+      expect(current_path).to eq("/profile")
+      
+      order = Order.last
+      
+      order.item_orders.each do |item|
+        expect(item.status).to eq("unfulfilled")
+      end
+      
+      expect(order.status).to eq("cancelled")
+      
+      paper = Item.last
+      expect(paper.inventory).to eq(3)
+      
+      expect(page).to have_content("Your order has been cancelled")
     end
   end
   

--- a/spec/features/users/profile_order_spec.rb
+++ b/spec/features/users/profile_order_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe "As a registered user, when I visit my Profile Orders page" do
     click_on("Orders")
     expect(current_path).to eq('/profile/orders')
 
-    save_and_open_page
   end
 
 end
@@ -102,7 +101,6 @@ RSpec.describe "As a registered user, when I visit my Profile Orders page" do
 
     click_on("Order Number: #{@order_1.id}")
     expect(current_path).to eq("/orders/#{@order_1.id}")
-save_and_open_page
     expect(page).to have_content(@order_1.id)
     expect(page).to have_content(@order_1.created_at)
     expect(page).to have_content(@order_1.updated_at)


### PR DESCRIPTION
Also added functionality to decrease an Item's inventory when items are purchase, and also to increase an Item's inventory when orders are cancelled.

User Story 30, User cancels an order

As a registered user
When I visit an order's show page
I see a button or link to cancel the order
When I click the cancel button for an order, the following happens:
- Each row in the "order items" table is given a status of "unfulfilled"
- The order itself is given a status of "cancelled"
- Any item quantities in the order that were previously fulfilled have their quantities returned to their respective merchant's inventory for that item.
- I am returned to my profile page
- I see a flash message telling me the order is now cancelled
- And I see that this order now has an updated status of "cancelled"