### PR TITLE
User story 40 & 41

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -11,9 +11,16 @@ class Admin::MerchantsController < Admin::BaseController
 
     def update
       merchant = Merchant.find(params[:id])
-      merchant.update(disabled: true)
-      merchant.deactivate_items
-      flash[:notice] = "#{merchant.name}'s account has been disabled."
-      redirect_to "/admin/merchants"
+      if merchant.disabled == false
+        merchant.update(disabled: true)
+        merchant.deactivate_items
+        flash[:notice] = "#{merchant.name}'s account has been disabled."
+        redirect_to "/admin/merchants"
+      else
+        merchant.update(disabled: false)
+        merchant.activate_items
+        flash[:notice] = "#{merchant.name}'s account is now enabled."
+        redirect_to "/admin/merchants"
+      end
     end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -40,5 +40,12 @@ class Merchant <ApplicationRecord
       item.save
     end
   end
+  
+  def activate_items
+    items.each do |item|
+      item.update(active?: true)
+      item.save
+    end
+  end
 
 end

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -19,6 +19,7 @@
       <% if merchant.disabled? %>
       <section class = "grid-item", id="merchant-<%= merchant.id %>">
         <h2><%=link_to merchant.name, "/admin/merchants/#{merchant.id}"%></h2>
+        <p><%=button_to "Enable", "/admin/merchants/#{merchant.id}", method: :patch%></p>
       </section>
       <% end %>
     <% end %>

--- a/spec/features/admin/admin_user_spec.rb
+++ b/spec/features/admin/admin_user_spec.rb
@@ -248,4 +248,56 @@ RSpec.describe "As an Admin" do
       expect(item.active?).to eq(false)
     end
   end
+  
+  it "can enable merchants" do
+    admin = User.create(name: "Jim Bob Manager Extraordinaire",
+                       address: "2020 Whiskey River Blvd",
+                       city: "Bamaville",
+                       state: "AL",
+                       zip: "33675",
+                       email: "jimbobwoowoo@aol.com",
+                       password: "merica4lyfe",
+                       role: 2)
+    mike = Merchant.create(name: "Mike's Print Shop", address: '123 Paper Rd.', city: 'Denver', state: 'CO', zip: 80203)
+    meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+    paper = mike.items.create(name: "Lined Paper", description: "Great for writing on!", price: 20, image: "https://cdn.vertex42.com/WordTemplates/images/printable-lined-paper-wide-ruled.png", inventory: 3)
+    pencil = mike.items.create(name: "Yellow Pencil", description: "You can write on paper with it!", price: 2, image: "https://images-na.ssl-images-amazon.com/images/I/31BlVr01izL._SX425_.jpg", inventory: 100)
+    regular_user = User.create!(name: "Harry Richard", address: "1234 Bland St.", city: "Denver", state: "CO", zip: "80085", email: "regular_user@email.com", password: "123", role: 0)
+    order_1 = regular_user.orders.create!(name: regular_user.name, address: regular_user.address, city: regular_user.city, state: regular_user.state, zip: regular_user.zip)
+    order_1.item_orders.create!(status: "pending", item: paper, price: paper.price, quantity: 1)
+    order_1.item_orders.create!(status: "pending", item: pencil, price: pencil.price, quantity: 12)
+    visit "/merchants"
+    click_on "Login"
+    fill_in :password, with: admin.password
+    fill_in :email, with: admin.email
+    click_on "Submit"
+    visit "/admin/merchants"
+    expect(page).to have_content(mike.name)
+    expect(page).to have_content(meg.name)
+    expect(page).to have_button("Disable")
+    
+    within("#merchant-#{mike.id}") do
+      click_on "Disable"
+    end
+    expect(current_path).to eq("/admin/merchants")
+    within("#valid-merchants") do
+      expect(page).to have_content(meg.name)
+    end
+    within("#disabled-merchants") do
+      expect(page).to have_content(mike.name)
+    end
+    expect(page).to have_content("#{mike.name}'s account has been disabled.")
+  
+    within("#merchant-#{mike.id}") do
+      click_on "Enable"
+    end
+    expect(current_path).to eq("/admin/merchants")
+    within("#valid-merchants") do
+      expect(page).to have_content(meg.name)
+    end
+    within("#valid-merchants") do
+      expect(page).to have_content(mike.name)
+    end
+    expect(page).to have_content("#{mike.name}'s account is now enabled.")
+  end
 end

--- a/spec/features/admin/admin_user_spec.rb
+++ b/spec/features/admin/admin_user_spec.rb
@@ -300,4 +300,46 @@ RSpec.describe "As an Admin" do
     end
     expect(page).to have_content("#{mike.name}'s account is now enabled.")
   end
+  
+  it "can activate merchant's items when it is enabled" do
+
+    admin = User.create(name: "Jim Bob Manager Extraordinaire",
+                      address: "2020 Whiskey River Blvd",
+                      city: "Bamaville",
+                      state: "AL",
+                      zip: "33675",
+                      email: "jimbobwoowoo@aol.com",
+                      password: "merica4lyfe",
+                      role: 2)
+    mike = Merchant.create(name: "Mike's Print Shop", address: '123 Paper Rd.', city: 'Denver', state: 'CO', zip: 80203)
+    meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+    paper = mike.items.create(name: "Lined Paper", description: "Great for writing on!", price: 20, image: "https://cdn.vertex42.com/WordTemplates/images/printable-lined-paper-wide-ruled.png", inventory: 3)
+    pencil = mike.items.create(name: "Yellow Pencil", description: "You can write on paper with it!", price: 2, image: "https://images-na.ssl-images-amazon.com/images/I/31BlVr01izL._SX425_.jpg", inventory: 100)
+    regular_user = User.create!(name: "Harry Richard", address: "1234 Bland St.", city: "Denver", state: "CO", zip: "80085", email: "regular_user@email.com", password: "123", role: 0)
+    order_1 = regular_user.orders.create!(name: regular_user.name, address: regular_user.address, city: regular_user.city, state: regular_user.state, zip: regular_user.zip)
+    order_1.item_orders.create!(status: "pending", item: paper, price: paper.price, quantity: 1)
+    order_1.item_orders.create!(status: "pending", item: pencil, price: pencil.price, quantity: 12)
+    visit "/merchants"
+    click_on "Login"
+    fill_in :password, with: admin.password
+    fill_in :email, with: admin.email
+    click_on "Submit"
+    visit "/admin/merchants"
+    expect(page).to have_content(mike.name)
+    expect(page).to have_content(meg.name)
+    expect(page).to have_button("Disable")
+    within("#merchant-#{mike.id}") do
+      click_on "Disable"
+    end
+    mike.items.each do |item|
+      expect(item.active?).to eq(false)
+    end
+    expect(page).to have_button("Enable")
+    within("#merchant-#{mike.id}") do
+      click_on "Enable"
+    end
+    Item.all.each do |item|
+      expect(item.active?).to eq(true)
+    end
+  end
 end


### PR DESCRIPTION
User Story 40, Admin enables a merchant account

As an admin
When I visit the merchant index page
I see an "enable" button next to any merchants whose accounts are disabled
When I click on the "enable" button
I am returned to the admin's merchant index page where I see that the merchant's account is now enabled
And I see a flash message that the merchant's account is now enabled

User Story 41, Enabled Merchant Item's are active

As an admin
When I visit the merchant index page
And I click on the "enable" button for a disabled merchant
Then all of that merchant's items should be activated