### PR TITLE
Story 49 & 50

### DIFF
--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -47,7 +47,7 @@ class Cart
   def out_of_stock?(item_id)
     item_count(item_id) == Item.find(item_id).inventory
   end
-  
+
   def modify(order)
     items.each do |item,quantity|
       item.modify_item_inventory(item, quantity, :decrease)
@@ -55,7 +55,7 @@ class Cart
         item: item,
         quantity: quantity,
         price: item.price,
-        status: "pending"
+        status: "unfulfilled"
         })
     end
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,7 @@
       <%= link_to "Logout", "/logout", method: :delete %>
 
     <% elsif current_merchant? %>
-      <%= link_to "Merchant Dashboard", "/merchant/dashboard" %>
+      <%= link_to "Merchant Dashboard", "/merchant" %>
       <%= link_to "Profile", "/profile" %>
       <%= link_to "Logout", "/logout", method: :delete %>
       <%= link_to "Cart: #{cart.total_items}", "/cart" %>

--- a/app/views/merchant/orders/show.html.erb
+++ b/app/views/merchant/orders/show.html.erb
@@ -31,7 +31,7 @@
   <% @order.item_orders.each do |item_order|%>
     <tr>
     <section id = "item-order">
-
+      <% if item_order.item.merchant_id == current_user.merchant_id %>
         <td><p><%=link_to item_order.item.name, "/items/#{item_order.item_id}"%></p>
         <div class="thumbnail"><img id="thumbnail"  src=<%="#{item_order.item.image}"%> alt=<%= "#{item_order.item.name}" %>
         </div></td>
@@ -42,6 +42,7 @@
         <% if item_order.status == "pending"%>
           <td><%= button_to "Fulfill Item", "/merchant/orders/#{@order.id}/items/#{item_order.item.id}/update", method: :patch %></td>
         <% end %>
+      <% end %>
       </section>
     </tr>
   <% end %>

--- a/app/views/merchant/orders/show.html.erb
+++ b/app/views/merchant/orders/show.html.erb
@@ -30,7 +30,7 @@
     </tr>
   <% @order.item_orders.each do |item_order|%>
     <tr>
-    <section id = "item-order">
+    <section id = "item-order-for-item-<%= item_order.item.id %>">
       <% if item_order.item.merchant_id == current_user.merchant_id %>
         <td><p><%=link_to item_order.item.name, "/items/#{item_order.item_id}"%></p>
         <div class="thumbnail"><img id="thumbnail"  src=<%="#{item_order.item.image}"%> alt=<%= "#{item_order.item.name}" %>
@@ -39,8 +39,10 @@
         <td><p><%= number_to_currency(item_order.price)%></p></td>
         <td><p><%= item_order.quantity%></p></td>
         <td><p><%= number_to_currency(item_order.subtotal)%></p></td>
-        <% if item_order.status == "pending"%>
+        <% if item_order.status == "unfulfilled"%>
           <td><%= button_to "Fulfill Item", "/merchant/orders/#{@order.id}/items/#{item_order.item.id}/update", method: :patch %></td>
+        <% else %>
+        <td><p>Item Fulfilled</p></td>
         <% end %>
       <% end %>
       </section>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -42,9 +42,9 @@ third_user = User.create!(name: "Scooby Doo", address: "133 Main St.", city: "De
 fourth_user = User.create!(name: "Jerry McGuire", address: "14 Harry St.", city: "Denver", state: "CO", zip: "80085", email: "fourth_user@email.com", password: "123", role: 0)
 merchant_user = User.create!(name: "James Bond", address: "1234 Bland St.", city: "Denver", state: "CO", zip: "80085", email: "merchant_user@email.com", password: "123", role: 1, merchant_id: chris.id)
 order_1 = regular_user.orders.create!(name: regular_user.name, address: regular_user.address, city: regular_user.city, state: regular_user.state, zip: regular_user.zip)
-order_1.item_orders.create!(status: "fulfilled", item: tire, price: tire.price, quantity: 3)
-order_1.item_orders.create!(status: "fulfilled", item: paper, price: paper.price, quantity: 1)
-order_1.item_orders.create!(status: "fulfilled", item: pencil, price: pencil.price, quantity: 12)
+order_1.item_orders.create!(status: "unfulfilled", item: tire, price: tire.price, quantity: 3)
+order_1.item_orders.create!(status: "unfulfilled", item: paper, price: paper.price, quantity: 1)
+order_1.item_orders.create!(status: "unfulfilled", item: pencil, price: pencil.price, quantity: 12)
 
 order_2 = second_user.orders.create!(name: second_user.name, address: second_user.address, city: second_user.city, state: second_user.state, zip: second_user.zip, status: "packaged")
 order_2.item_orders.create!(status: "fulfilled", item: tire, price: tire.price, quantity: 2)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -30,6 +30,7 @@ admin = User.create(name: "Jim Bob Manager Extraordinaire",
                    email: "jimbobwoowoo@aol.com",
                    password: "merica4lyfe",
                    role: 2)
+
 chris = Merchant.create(name: "Chris's Print Shop", address: '123 Paper Rd.', city: 'Denver', state: 'CO', zip: 80203)
 garrett = Merchant.create(name: "Garrett's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
 tire = garrett.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
@@ -39,7 +40,7 @@ regular_user = User.create!(name: "Harry Richard", address: "1234 Bland St.", ci
 second_user = User.create!(name: "Drew Bob", address: "1 Bland St.", city: "Denver", state: "CO", zip: "80085", email: "second_user@email.com", password: "123", role: 0)
 third_user = User.create!(name: "Scooby Doo", address: "133 Main St.", city: "Denver", state: "CO", zip: "80085", email: "third_user@email.com", password: "123", role: 0)
 fourth_user = User.create!(name: "Jerry McGuire", address: "14 Harry St.", city: "Denver", state: "CO", zip: "80085", email: "fourth_user@email.com", password: "123", role: 0)
-merchant_user = 
+merchant_user = User.create!(name: "James Bond", address: "1234 Bland St.", city: "Denver", state: "CO", zip: "80085", email: "merchant_user@email.com", password: "123", role: 1, merchant_id: chris.id)
 order_1 = regular_user.orders.create!(name: regular_user.name, address: regular_user.address, city: regular_user.city, state: regular_user.state, zip: regular_user.zip)
 order_1.item_orders.create!(status: "fulfilled", item: tire, price: tire.price, quantity: 3)
 order_1.item_orders.create!(status: "fulfilled", item: paper, price: paper.price, quantity: 1)

--- a/spec/features/merchant/orders/show_spec.rb
+++ b/spec/features/merchant/orders/show_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe "Order Packaged" do
+    before(:each) do
+      @mike = Merchant.create(name: "Mike's Print Shop", address: '123 Paper Rd.', city: 'Denver', state: 'CO', zip: 80203)
+      @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+      @tire = @meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+      @paper = @mike.items.create(name: "Lined Paper", description: "Great for writing on!", price: 20, image: "https://cdn.vertex42.com/WordTemplates/images/printable-lined-paper-wide-ruled.png", inventory: 3)
+      @pencil = @mike.items.create(name: "Yellow Pencil", description: "You can write on paper with it!", price: 2, image: "https://images-na.ssl-images-amazon.com/images/I/31BlVr01izL._SX425_.jpg", inventory: 100)
+
+      @merchant_user = User.create!(name: "Joe Shmoe", address: "4321 Active St.", city: "BPo", state: "CT", zip: "80345", email: "merchant_user@email.com", password: "1234", role: 1, merchant_id: @meg.id)
+
+      @regular_user = User.create!(name: "Harry Richard", address: "1234 Bland St.", city: "Denver", state: "CO", zip: "80085", email: "regular_user@email.com", password: "123", role: 0, merchant_id: nil)
+      @order_1 = @regular_user.orders.create!(name: @regular_user.name, address: @regular_user.address, city: @regular_user.city, state: @regular_user.state, zip: @regular_user.zip)
+      @item_order1 = @order_1.item_orders.create!(status: "unfulfilled", item: @tire, price: @tire.price, quantity: 3)
+      @item_order2 = @order_1.item_orders.create!(status: "unfulfilled", item: @paper, price: @paper.price, quantity: 3)
+
+
+      visit "/items"
+      click_on "Login"
+      fill_in :email, with: @merchant_user.email
+      fill_in :password, with: @merchant_user.password
+      click_on "Submit"
+    end
+
+    it "" do
+      visit "/merchant/orders/#{@order_1.id}"
+      expect(page).to have_content(@regular_user.name)
+      expect(page).to have_content(@regular_user.address)
+      expect(page).to have_content(@regular_user.city)
+      expect(page).to have_content(@regular_user.state)
+      expect(page).to have_content(@regular_user.zip)
+      expect(page).to_not have_content(@paper.name)
+      expect(page).to have_content(@tire.name)
+      expect(page).to have_xpath("//img[@src='#{@tire.image}']")
+      expect(page).to have_content(@tire.price)
+      expect(page).to have_content(@tire.price)
+      expect(page).to have_content(@item_order1.quantity)
+    end
+
+#     User Story 49, Merchant sees an order show page
+#
+# As a merchant employee
+# When I visit an order show page from my dashboard
+# I see the recipients name and address that was used to create this order
+# I only see the items in the order that are being purchased from my merchant
+# I do not see any items in the order being purchased from other merchants
+# For each item, I see the following information:
+# - the name of the item, which is a link to my item's show page
+# - an image of the item
+# - my price for the item
+# - the quantity the user wants to purchase
+end

--- a/spec/features/merchant/orders/show_spec.rb
+++ b/spec/features/merchant/orders/show_spec.rb
@@ -37,4 +37,30 @@ RSpec.describe "Order Packaged" do
       expect(page).to have_content(@tire.price)
       expect(page).to have_content(@item_order1.quantity)
     end
+
+    it "can fulfill part of an order" do
+      visit "/merchant/orders/#{@order_1.id}"
+      within("#item-order-for-item-#{@tire.id}") do
+        click_on "Fulfill Item"
+      end
+      expect(current_path).to eq("/merchant/orders/#{@order_1.id}")
+      expect(page).to have_content("Item has been fulfilled")
+      expect(page).to have_content("Item Fulfilled")
+      expect(ItemOrder.all.first.item.inventory).to eq(9)
+    end
+
+#     User Story 50, Merchant fulfills part of an order
+#
+# As a merchant employee
+# When I visit an order show page from my dashboard
+# For each item of mine in the order
+# If the user's desired quantity is equal to or less than my current inventory quantity for that item
+# And I have not already "fulfilled" that item:
+# - Then I see a button or link to "fulfill" that item
+# - When I click on that link or button I am returned to the order show page
+# - I see the item is now fulfilled
+# - I also see a flash message indicating that I have fulfilled that item
+# - the item's inventory quantity is permanently reduced by the user's desired quantity
+#
+# If I have already fulfilled this item, I see text indicating such.
 end

--- a/spec/features/merchant/orders/show_spec.rb
+++ b/spec/features/merchant/orders/show_spec.rb
@@ -37,17 +37,4 @@ RSpec.describe "Order Packaged" do
       expect(page).to have_content(@tire.price)
       expect(page).to have_content(@item_order1.quantity)
     end
-
-#     User Story 49, Merchant sees an order show page
-#
-# As a merchant employee
-# When I visit an order show page from my dashboard
-# I see the recipients name and address that was used to create this order
-# I only see the items in the order that are being purchased from my merchant
-# I do not see any items in the order being purchased from other merchants
-# For each item, I see the following information:
-# - the name of the item, which is a link to my item's show page
-# - an image of the item
-# - my price for the item
-# - the quantity the user wants to purchase
 end

--- a/spec/features/merchant/orders/show_spec.rb
+++ b/spec/features/merchant/orders/show_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Order Packaged" do
       click_on "Submit"
     end
 
-    it "" do
+    it "can view my merchant items on my order show page that are in a user's item order" do
       visit "/merchant/orders/#{@order_1.id}"
       expect(page).to have_content(@regular_user.name)
       expect(page).to have_content(@regular_user.address)


### PR DESCRIPTION
User Story 49, Merchant sees an order show page

As a merchant employee
When I visit an order show page from my dashboard
I see the recipients name and address that was used to create this order
I only see the items in the order that are being purchased from my merchant
I do not see any items in the order being purchased from other merchants
For each item, I see the following information:
- the name of the item, which is a link to my item's show page
- an image of the item
- my price for the item
- the quantity the user wants to purchase

User Story 50, Merchant fulfills part of an order

As a merchant employee
When I visit an order show page from my dashboard
For each item of mine in the order
If the user's desired quantity is equal to or less than my current inventory quantity for that item
And I have not already "fulfilled" that item:
- Then I see a button or link to "fulfill" that item
- When I click on that link or button I am returned to the order show page
- I see the item is now fulfilled
- I also see a flash message indicating that I have fulfilled that item
- the item's inventory quantity is permanently reduced by the user's desired quantity

If I have already fulfilled this item, I see text indicating such.