### PR TITLE
DONE! User story 47 & 48

### DIFF
--- a/app/controllers/merchant/items_controller.rb
+++ b/app/controllers/merchant/items_controller.rb
@@ -21,4 +21,27 @@ class Merchant::ItemsController < Merchant::BaseController
     flash[:success] = "Item has been deleted"
     redirect_to "/merchant/items"
   end
+  
+  def edit
+    @item = Item.find(params[:item_id])
+  end
+  
+  def update
+    @item = Item.find(params[:item_id])
+    updated = @item.updated_at
+    @item.update(item_params)
+    if @item.updated_at != updated
+      flash[:success] = "Item has been updated"
+      redirect_to "/merchant/items"
+    else
+      flash[:error] = @item.errors.full_messages.to_sentence
+      render :edit
+    end
+  end
+  
+  private
+  
+  def item_params
+   params.permit(:name,:description,:price,:inventory,:image)
+  end
 end

--- a/app/views/merchant/items/edit.html.erb
+++ b/app/views/merchant/items/edit.html.erb
@@ -1,0 +1,20 @@
+<center>
+<%= form_tag "/merchant/items/#{@item.id}/edit", method: :patch do %>
+<%= label_tag :name %>
+<%= text_field_tag :name, "#{@item.name}"%>
+
+ <%= label_tag :description %>
+<%= text_field_tag :description, "#{@item.description}" %>
+
+ <%= label_tag :price %>
+<%= text_field_tag :price, "#{@item.price}" %>
+
+ <%= label_tag :image %>
+<%= text_field_tag :image, "#{@item.image}" %>
+
+ <%= label_tag :inventory %>
+<%= text_field_tag :inventory, "#{@item.inventory}" %>
+
+ <%= submit_tag 'Submit Edits' %>
+<% end %>
+</center>

--- a/app/views/merchant/items/index.html.erb
+++ b/app/views/merchant/items/index.html.erb
@@ -15,5 +15,6 @@
       <% else %>
         <%= link_to "Activate", "/merchant/items/#{item.id}", method: :patch %>
       <% end  %>
+    <%= link_to "Edit Item", "/merchant/items/#{item.id}/edit"%>
 </section>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,8 @@ Rails.application.routes.draw do
     patch "/orders/:order_id/items/:item_id/update", to: "orders#update"
     patch "/items/:id", to: "items#update_activation"
     delete "/items/:id", to: "items#destroy"
+    get "/items/:item_id/edit", to: "items#edit"
+    patch "/items/:item_id/edit", to: "items#update"
   end
 
   get "/merchants", to: "merchants#index"

--- a/spec/features/merchant/items/edit_spec.rb
+++ b/spec/features/merchant/items/edit_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe "As a merchant employee" do
+  before :each do
+    @meg = Merchant.create!(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+    @tire = @meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+    @employee_user = User.create!(name: "Joe Shmoe", address: "1234 Bland St.", city: "Denver", state: "CO", zip: "80085", email: "regular_user@email.com", password: "123", role: 1, merchant_id: @meg.id)
+
+    visit '/'
+    within ".topnav" do
+      click_link("Login")
+    end
+    
+    fill_in :email, with: @employee_user.email
+    fill_in :password, with: @employee_user.password
+    click_on "Submit"
+    click_link("My Items")
+    expect(current_path).to eq("/merchant/items")
+  end
+
+  it "Has a form for a new item" do
+    click_on("Edit Item")
+    expect(current_path).to eq("/merchant/items/#{@tire.id}/edit")
+
+    name = "Chamois Butter"
+    price = 18
+    description = "No more chaffin'!"
+    image_url = "https://images-na.ssl-images-amazon.com/images/I/51HMpDXItgL._SX569_.jpg"
+    inventory = 25
+    
+    expect(find_field('Name').value).to eq "#{@tire.name}"
+    expect(find_field('Price').value).to eq "#{@tire.price}"
+    expect(find_field('Description').value).to eq "#{@tire.description}"
+    expect(find_field('Image').value).to eq("#{@tire.image}")
+    expect(find_field('Inventory').value).to eq "#{@tire.inventory}"
+    
+    
+    fill_in :name, with: ""
+    fill_in :price, with: ""
+    fill_in :description, with: ""
+    fill_in :image, with: image_url
+    fill_in :inventory, with: ""
+
+    click_button "Submit Edits"
+
+    expect(page).to have_content("Name can't be blank, Description can't be blank, Price can't be blank, Price is not a number, and Inventory can't be blank")
+    expect(current_path).to eq("/merchant/items/#{@tire.id}/edit")
+
+    fill_in :name, with: name
+    fill_in :price, with: price
+    fill_in :description, with: description
+    fill_in :image, with: image_url
+    fill_in :inventory, with: inventory
+
+    click_button "Submit Edits"
+
+    expect(current_path).to eq('/merchant/items')
+    
+    expect(page).to have_content("Item has been updated")
+    expect(page).to have_content(name)
+    expect(page).to have_content(price)
+    expect(page).to have_content(description)
+    expect(page).to have_content(inventory)
+  end
+end

--- a/spec/features/merchant/items/index_spec.rb
+++ b/spec/features/merchant/items/index_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe "As a merchant employee" do
         expect(page).to have_content("Inventory: #{@gator_tire.inventory}")
       end
     end
+    
 
     it "I can click a link or button to deactivate items" do
 


### PR DESCRIPTION
I did not implement an image placeholder for this story, I remember someone else had done this for another story, but could not find where it was implemented.  If we have not done an image placeholder yet, let me know and I'll add it!!

User Story 47, Merchant edits an item

As a merchant employee
When I visit my items page
And I click the edit button or link next to any item
Then I am taken to a form similar to the 'new item' form
The form is pre-populated with all of this item's information
I can change any information, but all of the rules for adding a new item still apply:
- name and description cannot be blank
- price cannot be less than $0.00
- inventory must be 0 or greater

When I submit the form
I am taken back to my items page
I see a flash message indicating my item is updated
I see the item's new information on the page, and it maintains its previous enabled/disabled state
If I left the image field blank, I see a placeholder image for the thumbnail

User Story 48, Merchant cannot edit an item if details are bad/missing

As a merchant employee
When I try to edit an existing item
If any of my data is incorrect or missing (except image)
Then I am returned to the form
I see one or more flash messages indicating each error I caused
All fields are re-populated with my previous data